### PR TITLE
Fixes #16

### DIFF
--- a/Docs/Stations/GetNearest.md
+++ b/Docs/Stations/GetNearest.md
@@ -1,0 +1,2 @@
+Returns a list of available station resources within a specified search radius.
+

--- a/Docs/Stations/GetNearest.md
+++ b/Docs/Stations/GetNearest.md
@@ -1,2 +1,2 @@
-Returns a list of available station resources within a specified search radius.
+Returns a list of available station resources within a specified search radius (kilometers).
 

--- a/Docs/Stations/GetNearestOnNetwork.md
+++ b/Docs/Stations/GetNearestOnNetwork.md
@@ -1,1 +1,1 @@
-Returns a list of NLDI stations located on the network within a specified search distance.
+Returns a list of NLDI stations located on the network within a specified search distance (kilometers).

--- a/Docs/Stations/GetNearestOnNetwork.md
+++ b/Docs/Stations/GetNearestOnNetwork.md
@@ -1,0 +1,1 @@
+Returns a list of NLDI stations located on the network within a specified search distance.

--- a/GageStatsAgent/GageStatsAgent.cs
+++ b/GageStatsAgent/GageStatsAgent.cs
@@ -250,10 +250,9 @@ namespace GageStatsAgent
         }
         public IQueryable<Station> GetNearest(double lat, double lon, double radius)
         {
-            var query = String.Format(getSQLStatement(sqltypeenum.stationsbyradius), lat, lon, radius);//@"SELECT * FROM gagestats.""Stations"" as st where ST_Contains(st_transform(ST_Buffer(st_geomfromtext('Point({1} {0})',4326)::geography, {2})::geometry, 4326), st.""Location"")", lat, lon, radius);
+            var query = String.Format(getSQLStatement(sqltypeenum.stationsbyradius), lat, lon, radius);
             return FromSQL<Station>(query);
         }
-
         public Task<Station> Add(Station item)
         {
             return Add<Station>(item);

--- a/GageStatsAgent/GageStatsAgent.cs
+++ b/GageStatsAgent/GageStatsAgent.cs
@@ -250,7 +250,8 @@ namespace GageStatsAgent
         }
         public IQueryable<Station> GetNearest(double lat, double lon, double radius)
         {
-            var query = String.Format(getSQLStatement(sqltypeenum.stationsbyradius), lat, lon, radius);
+            var radius_m = radius * 1000; //GageStatsDB searches in meters by default, user has specified km
+            var query = String.Format(getSQLStatement(sqltypeenum.stationsbyradius), lat, lon, radius_m);
             return FromSQL<Station>(query);
         }
         public Task<Station> Add(Station item)

--- a/GageStatsServices/Controllers/StationsController.cs
+++ b/GageStatsServices/Controllers/StationsController.cs
@@ -31,6 +31,9 @@ using GageStatsDB.Resources;
 using WIM.Exceptions.Services;
 using System.Linq;
 using System.IO;
+using GageStatsAgent.Resources;
+using Microsoft.Extensions.Options;
+using GageStatsAgent.ServiceAgents;
 
 namespace GageStatsServices.Controllers
 {
@@ -39,8 +42,12 @@ namespace GageStatsServices.Controllers
     public class StationsController : WIM.Services.Controllers.ControllerBase
     {
         public IGageStatsAgent agent { get; set; }
-        public StationsController(IGageStatsAgent agent ) : base()
+        private NLDISettings NLDIsettings { get; set; }
+        private NavigationSettings Navigationsettings { get; set; }
+        public StationsController(IGageStatsAgent agent, IOptions<NLDISettings> nldisettings, IOptions<NavigationSettings> navsettings) : base()
         {
+            NLDIsettings = nldisettings.Value;
+            Navigationsettings = navsettings.Value;
             this.agent = agent;
         }
         #region METHODS
@@ -102,7 +109,7 @@ namespace GageStatsServices.Controllers
         }
 
         [HttpGet("Nearest", Name = "Nearest Station")]
-        [APIDescription(type = DescriptionType.e_link, Description = "/Docs/Stations/GetDistinct.md")]
+        [APIDescription(type = DescriptionType.e_link, Description = "")]
         public async Task<IActionResult> Nearest([FromQuery]double lat, [FromQuery]double lon, [FromQuery]double radius, [FromQuery] int page = 1, [FromQuery] int pageCount = 50)
         {
             try
@@ -118,6 +125,27 @@ namespace GageStatsServices.Controllers
             {
                 return await HandleExceptionAsync(ex);
             }
+        }
+
+        [HttpGet("Network", Name = "Nearest Stations on Network")]
+        [APIDescription(type = DescriptionType.e_link, Description = "")]
+        public async Task<IActionResult> Network([FromQuery] double lat, [FromQuery] double lon, [FromQuery] double distance, [FromQuery] int page = 1, [FromQuery] int pageCount = 50)
+        {
+            try
+            {
+                //var nav_sa = new NavigationServiceAgent(this.Navsettings);
+                var nldi_sa = new NLDIServiceAgent(this.NLDIsettings, this.Navigationsettings);
+                var isOk = await nldi_sa.ReadNLDIAsync(lat, lon, distance);
+
+                if (!isOk) throw new Exception("Failed to retrieve NLDI data");
+                return Ok(nldi_sa.getStations());
+
+            }
+            catch (Exception ex)
+            {                
+                return await HandleExceptionAsync(ex);
+            }
+            
         }
 
         [HttpPost(Name = "Add Station")]

--- a/GageStatsServices/Controllers/StationsController.cs
+++ b/GageStatsServices/Controllers/StationsController.cs
@@ -139,13 +139,11 @@ namespace GageStatsServices.Controllers
 
                 if (!isOk) throw new Exception("Failed to retrieve NLDI data");
                 return Ok(nldi_sa.getStations());
-
             }
             catch (Exception ex)
             {                
                 return await HandleExceptionAsync(ex);
-            }
-            
+            }            
         }
 
         [HttpPost(Name = "Add Station")]

--- a/GageStatsServices/Controllers/StationsController.cs
+++ b/GageStatsServices/Controllers/StationsController.cs
@@ -109,17 +109,14 @@ namespace GageStatsServices.Controllers
         }
 
         [HttpGet("Nearest", Name = "Nearest Station")]
-        [APIDescription(type = DescriptionType.e_link, Description = "")]
-        public async Task<IActionResult> Nearest([FromQuery]double lat, [FromQuery]double lon, [FromQuery]double radius, [FromQuery] int page = 1, [FromQuery] int pageCount = 50)
+        [APIDescription(type = DescriptionType.e_link, Description = "GetNearest.md")]
+        public async Task<IActionResult> Nearest([FromQuery]double lat, [FromQuery]double lon, [FromQuery]double radius)
         {
             try
             {
                 IQueryable<Station> gages = agent.GetNearest(lat, lon, radius);
 
-                // get number of items to skip for pagination
-                var skip = (page - 1) * pageCount;
-                sm("Returning page " + page + " of " + (gages.Count() / pageCount + 1) + ".");
-                return Ok(gages.Skip(skip).Take(pageCount));
+                return Ok(gages);
             }
             catch (Exception ex)
             {
@@ -128,7 +125,7 @@ namespace GageStatsServices.Controllers
         }
 
         [HttpGet("Network", Name = "Nearest Stations on Network")]
-        [APIDescription(type = DescriptionType.e_link, Description = "")]
+        [APIDescription(type = DescriptionType.e_link, Description = "GetNearestOnNetwork.md")]
         public async Task<IActionResult> Network([FromQuery] double lat, [FromQuery] double lon, [FromQuery] double distance, [FromQuery] int page = 1, [FromQuery] int pageCount = 50)
         {
             try

--- a/GageStatsServices/Resources/NLDISettings.cs
+++ b/GageStatsServices/Resources/NLDISettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GageStatsAgent.Resources
+{
+    public class NLDISettings
+    {
+        public string baseurl { get; set; }
+        public Dictionary<string, string> resources { get; set; }
+    }
+}

--- a/GageStatsServices/Resources/NavigationSettings.cs
+++ b/GageStatsServices/Resources/NavigationSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GageStatsAgent.Resources
+{
+    public class NavigationSettings
+    {
+        public string baseurl { get; set; }
+        public Dictionary<string, string> resources { get; set; }
+    }
+}

--- a/GageStatsServices/ServiceAgents/NLDIServiceAgent.cs
+++ b/GageStatsServices/ServiceAgents/NLDIServiceAgent.cs
@@ -135,25 +135,7 @@ namespace GageStatsAgent.ServiceAgents
 
         }
         //select generic storm event, All Cases and 50% probability
-        private async Task<double> getComid(double lat, double lon)
-        {
-            string urlString = "/NavigationServices/attributes?x=" + lon + "&y=" + lat;
-            double comid;
-            try
-            {
-                using (HttpClient conn = new HttpClient())
-                {
-                    conn.BaseAddress = new Uri("https://test.streamstats.usgs.gov");
-                    var reply = await conn.GetAsync(urlString, default(System.Threading.CancellationToken));
-                    comid = 1; //reply.COMID;
-                }
-                return comid;
-            }
-            catch(Exception)
-            {
-                return 0;
-            }
-        }
+        
         #endregion
         #region Enumerations
         public enum serviceType

--- a/GageStatsServices/ServiceAgents/NLDIServiceAgent.cs
+++ b/GageStatsServices/ServiceAgents/NLDIServiceAgent.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Net.Http;
+using GageStatsAgent.Resources;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace GageStatsAgent.ServiceAgents
+{
+    public class NLDIServiceAgent
+    {
+        #region Properties
+        public NLDISettings NLDIsettings { get; set; }
+        private NavigationSettings Navigationsettings { get; set; }
+        private object NLDIstations;
+
+        #endregion
+        #region Constructors
+        public NLDIServiceAgent(NLDISettings settings, NavigationSettings navsettings)
+
+        {
+            this.NLDIsettings = settings;
+            this.Navigationsettings = navsettings;
+        }
+        #endregion
+        #region Methods
+        public async Task<bool> ReadNLDIAsync(double lat, double lon, double distance)
+        {
+            string result = "";
+            string msg;
+            dynamic obj = null;
+
+            try
+            {
+                var sa = new NavigationServiceAgent(this.Navigationsettings);
+                var isOk = await sa.ReadNavigationAsync(lat, lon);
+
+                if (!isOk) throw new Exception("Failed to retrieve data from Navigation Services");
+
+                object[] args = { sa.getComid(), distance };
+                string urlString = String.Format(getURI(serviceType.e_downstream), args);
+
+                using (HttpClient conn = new HttpClient())                   
+                {
+                    conn.BaseAddress = new Uri(NLDIsettings.baseurl);
+
+                    var reply = await conn.GetAsync(urlString);
+                    result = reply.Content.ReadAsStringAsync().Result;
+                    if (result != "")
+                    {
+                        obj = JsonConvert.DeserializeObject<dynamic>(result);
+                    }
+                }
+
+                urlString = String.Format(getURI(serviceType.e_upstream), args);
+
+                using (HttpClient conn = new HttpClient())
+                {
+                    conn.BaseAddress = new Uri(NLDIsettings.baseurl);
+
+                    var reply = await conn.GetAsync(urlString);
+                    result = reply.Content.ReadAsStringAsync().Result;
+                    if (result != "")
+                    {
+                        if (obj)
+                        {
+                            obj = obj.add(JsonConvert.DeserializeObject<dynamic>(result));
+                        }
+                    }                    
+                    this.NLDIstations = obj;
+                }
+                if (isDynamicError(result, out msg)) throw new Exception(msg);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+        }//end PostFeatures
+        public object getStations()
+        {
+            if(this.NLDIstations != null)
+            {
+                return this.NLDIstations;
+            }
+            else
+            {
+                return "No stations located within search distance.";
+            }            
+        }
+
+        #endregion
+        #region Helper Methods
+
+        private String getURI(serviceType sType)
+        {
+            string uri = string.Empty;
+            
+            switch(sType)
+            {
+                case serviceType.e_downstream:
+                    uri = NLDIsettings.resources["downstreamQuery"];
+                    break;
+                case serviceType.e_upstream:
+                    uri = NLDIsettings.resources["upstreamQuery"];
+                    break;
+
+            }
+            return uri;
+        }//end getURL
+        private Boolean isDynamicError(dynamic obj, out string msg)
+        {
+            msg = string.Empty;
+            try
+            {
+                var error = obj.error;
+                if (error == null) throw new Exception();
+                msg = error.message;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+
+        }
+        //select generic storm event, All Cases and 50% probability
+        private async Task<double> getComid(double lat, double lon)
+        {
+            string urlString = "/NavigationServices/attributes?x=" + lon + "&y=" + lat;
+            double comid;
+            try
+            {
+                using (HttpClient conn = new HttpClient())
+                {
+                    conn.BaseAddress = new Uri("https://test.streamstats.usgs.gov");
+                    var reply = await conn.GetAsync(urlString, default(System.Threading.CancellationToken));
+                    comid = 1; //reply.COMID;
+                }
+                return comid;
+            }
+            catch(Exception)
+            {
+                return 0;
+            }
+        }
+        #endregion
+        #region Enumerations
+        public enum serviceType
+        {
+            e_downstream,
+            e_upstream
+        }
+        #endregion
+    }
+}

--- a/GageStatsServices/ServiceAgents/NavigationServiceAgent.cs
+++ b/GageStatsServices/ServiceAgents/NavigationServiceAgent.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Net.Http;
+using GageStatsAgent.Resources;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+namespace GageStatsAgent.ServiceAgents
+{
+    public class NavigationServiceAgent
+    {
+        #region Properties
+        public NavigationSettings settings { get; set; }
+        public string comid;
+
+        #endregion
+        #region Constructors
+        public NavigationServiceAgent(NavigationSettings settings)
+        {
+            this.settings = settings;
+        }
+        #endregion
+        #region Methods
+        public async Task<bool> ReadNavigationAsync(double lat, double lon)
+        {
+            string result = "";
+            string msg;
+
+            try
+            {
+                object[] args = { lat, lon };
+                string urlString = String.Format(getURI(), args);
+                using (HttpClient conn = new HttpClient())                   
+                {
+                    conn.BaseAddress = new Uri(settings.baseurl);
+
+                    var reply = await conn.GetAsync(urlString);
+
+                    result = reply.Content.ReadAsStringAsync().Result;
+                    dynamic obj = JsonConvert.DeserializeObject<dynamic>(result);
+                    this.comid = obj[0].COMID;
+                }
+
+                if (isDynamicError(result, out msg)) throw new Exception(msg);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+        }//end PostFeatures
+        public string getComid()
+        {
+            return this.comid;
+        }
+        #endregion
+        #region Helper Methods
+
+        private String getURI()
+        {
+            string uri = string.Empty;
+            
+            uri = settings.resources["navigationQuery"];
+
+            return uri;
+        }//end getURL
+        private Boolean isDynamicError(dynamic obj, out string msg)
+        {
+            msg = string.Empty;
+            try
+            {
+                var error = obj.error;
+                if (error == null) throw new Exception();
+                msg = error.message;
+                return true;
+            }
+            catch (Exception ex)
+            {
+
+                return false;
+            }
+
+        }
+        //select generic storm event, All Cases and 50% probability
+        private async Task<double> getComid(double lat, double lon)
+        {
+            string urlString = "/NavigationServices/attributes?x=" + lon + "&y=" + lat;
+            double comid;
+            try
+            {
+                using (HttpClient conn = new HttpClient())
+                {
+                    conn.BaseAddress = new Uri("https://test.streamstats.usgs.gov");
+
+                    var reply = await conn.GetAsync(urlString, default(System.Threading.CancellationToken));
+                    comid = 1; //reply.COMID;
+                }
+                return comid;
+            }
+            catch(Exception)
+            {
+                return 0;
+            }
+        }
+        #endregion
+    }
+}

--- a/GageStatsServices/Startup.cs
+++ b/GageStatsServices/Startup.cs
@@ -68,6 +68,8 @@ namespace GageStatsServices
             //Configure injectable obj
             services.AddScoped<IAnalyticsAgent, GoogleAnalyticsAgent>((gaa) => new GoogleAnalyticsAgent(Configuration["AnalyticsKey"]));
             services.Configure<APIConfigSettings>(Configuration.GetSection("APIConfigSettings"));
+            services.Configure<GageStatsAgent.Resources.NLDISettings>(Configuration.GetSection("NLDISettings"));
+            services.Configure<GageStatsAgent.Resources.NavigationSettings>(Configuration.GetSection("NavigationSettings"));
             services.Configure<JwtBearerSettings>(Configuration.GetSection("JwtBearerSettings"));
 
             //provides access to httpcontext

--- a/GageStatsServices/appsettings.json
+++ b/GageStatsServices/appsettings.json
@@ -9,7 +9,20 @@
     "SecretKey": "MY_Secret_Key123"
   },
   "AnalyticsKey": "",
-  "Version":  "1.0.0",
+  "Version": "1.0.0",
+  "NLDISettings": {
+    "baseurl": "https://labs.waterdata.usgs.gov",
+    "resources": {
+      "downstreamQuery": "/api/nldi/linked-data/comid/{0}/navigate/DD/nwissite?f=json&distance={1}",
+      "upstreamQuery": "/api/nldi/linked-data/comid/{0}/navigate/UT/nwissite?f=json&distance={1}"
+    }
+  },
+  "NavigationSettings": {
+    "baseurl": "https://test.streamstats.usgs.gov",
+    "resources": {
+      "navigationQuery": "/NavigationServices/attributes?x={1}&y={0}"
+    }
+  },
   "APIConfigSettings": {
     "pathDirectory": "https://raw.githubusercontent.com/USGS-WiM/GageStatsServices/staging",
     "parameters": {

--- a/GageStatsServices/appsettings.json
+++ b/GageStatsServices/appsettings.json
@@ -110,7 +110,10 @@
         "description": "Longitudinal location of user selected point in decimal degrees using ESRI SRID 4326"
       },
       "radius": {
-        "description": "Search radius distance in meters"
+        "description": "Search radius distance in kilometers"
+      },
+      "distance": {
+        "description": "Search distance along network (upstream and downstream) in kilometers"
       },
       "regions": {
         "description": "Comma-separated list of region IDs or codes",


### PR DESCRIPTION
Added new Network endpoint on stations controller to return NLDI stations located with search distance on the network. I created two service agents for each of the services (Navigation Services and NLDI Services).  I've been testing with the following requests, modifying the search distances to test all scenarios (no upstream sites, no downstream sites, no sites within distance, sites both upstream and downstream). 

http://localhost:53812/stations/Network?lat=41.606715&lon=-103.010559&distance=500
http://localhost:53812/stations/Network?lat=38.263928&lon=-104.551306&distance=200

I also took a guess and set this up to hit NLDI with a search for stations **downstream with diversions** and **upstream including tributaries**. If these are incorrect they can easily be changed. The options we have for NLDI navigate searches are below.

- DD is __D__ownstream navigation with __D__iversions
- DM is __D__ownstream navigation on the __M__ain channel
- UM is __U__pstream navigation on the __M__ain channel
- UT is __U__pstream navigation including all __T__ributaries